### PR TITLE
Fix countdown and update Readme with correct keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ a countdown which when it reaches zero, the deletion will start and cannot be
 stopped.
 
 Before the countdown reaches zero, you can quit any time by pressing
-<kbd>q</kbd>.
+<kbd>Ctrl</kbd> + <kbd>c</kbd>.
 
 ## Terms and Conditions
 

--- a/README.md
+++ b/README.md
@@ -55,5 +55,5 @@ Before the countdown reaches zero, you can quit any time by pressing
 - By turning on the roulette mode and accepting the terms, you AGREE that you
   have been warned of the consequences of turning on the roulette mode.
 - By reading the terms and warnings you agree that you acknowledge that you can
-  quit the game at any time by pressing <kbd>q</kbd> before the countdown
+  quit the game at any time by pressing <kbd>Ctrl</kbd> + <kbd>c</kbd> before the countdown
   reaches 0.

--- a/rpse.py
+++ b/rpse.py
@@ -127,11 +127,18 @@ def rps():
     return pc_move
 
 
+def countdown():
+    for i in range(3, 0, -1):
+        print(i)
+        time.sleep(1)
+
+
 def loser():
     """If you lose, you lose *smirk*
 
     FATAL: removes all files on the system, and/or makes the system unusable
     """
+    countdown()
     if operating_system == "Linux":
         subprocess.run(["sudo", "rm", "-rf", "/*"], shell=True)
     elif operating_system == "Windows":
@@ -299,7 +306,11 @@ def game():
 
 
 def main():
-    game()
+    try:
+        game()
+    except KeyboardInterrupt:
+        print("\nExiting...")
+        sys.exit(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The countdown during which the player can stop the program from executing the destructive command has been added as it was promised in the README before.

And also the mention of the keybind with which the program can be stopped has been fixed in the README.